### PR TITLE
feat: Scoping

### DIFF
--- a/codegen/rts/rts.ahk
+++ b/codegen/rts/rts.ahk
@@ -5,7 +5,7 @@ idris_putStr(x)
   MsgBox % x
 }
 
-idris_TheWorld()
+TheWorld()
 {
   return ""
 }

--- a/codegen/src/IdrisCG/AutoHotkey.hs
+++ b/codegen/src/IdrisCG/AutoHotkey.hs
@@ -8,6 +8,6 @@ import Relude
 
 codegenAHK :: Idris.CodeGenerator
 codegenAHK Idris.CodegenInfo {..} = do
-  let program = Program.generate liftDecls
+  program <- Program.generate liftDecls
   let renderedProgram = Render.renderToText $ Render.renderProgram program
   writeFile outputFile (RTS.contents <> renderedProgram)

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Block.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Block.hs
@@ -21,7 +21,7 @@ generate returning expression = case expression of
   Idris.LForce expr ->
     generate returning expr
   Idris.LApp _ (Idris.LV name) args -> do
-    let ahkName = Name.generate name
+    let ahkName = Variable (Name.generate name)
     let ahkArgs = map genExpr args
     [Call ahkName ahkArgs]
   Idris.LNothing ->
@@ -34,8 +34,8 @@ generate returning expression = case expression of
     let ahkArgs = map (genExpr . snd) params
     genForeign returning foreignName ahkArgs
   Idris.LLet name expr restExpressions -> do
-    let ahkName = Name.generate name
-    let ahkBind = generate (Let ahkName) expr
+    let ahkName = Variable (Name.generate name)
+    let ahkBind = generate (Assignment ahkName) expr
     ahkBind <> generate returning restExpressions
   Idris.LConst constExpr ->
     [returning $ Constant.generate constExpr]

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Block.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Block.hs
@@ -33,6 +33,23 @@ generate returning expression = case expression of
   Idris.LForeign _ foreignName params -> do
     let ahkArgs = map (genExpr . snd) params
     genForeign returning foreignName ahkArgs
+  Idris.LLet name expr restExpressions -> do
+    let ahkName = Name.generate name
+    let ahkBind = generate (Let ahkName) expr
+    ahkBind <> generate returning restExpressions
+  Idris.LConst constExpr ->
+    [returning $ Constant.generate constExpr]
+  Idris.LV name -> do
+    let ahkName = Name.generate name
+    [returning $ Apply (Variable ahkName) []]
+  Idris.LCase caseType exp alts ->
+    error $
+      unlines
+        [ "-------- LCase ----------",
+          show caseType,
+          show exp,
+          show alts
+        ]
   otherExpression ->
     error ("\nExpression not implemented \n\n\t" <> show (toConstr otherExpression) <> "\n")
 

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Common.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Common.hs
@@ -1,0 +1,16 @@
+module IdrisCG.AutoHotkey.Generate.Common where
+
+import IdrisCG.AutoHotkey.Syntax
+import Relude
+
+thisDot :: Expression -> Expression
+thisDot =
+  DotAccess (Variable $ Name "this")
+
+nullExpr :: Expression
+nullExpr = Literal (String "")
+
+copyFunArgs :: [Name] -> Block
+copyFunArgs names = do
+  let copyFunArg n = [Assignment (thisDot $ Variable n) (Variable n), Assignment (Variable n) nullExpr]
+  foldMap copyFunArg names

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Name.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Name.hs
@@ -1,5 +1,8 @@
 module IdrisCG.AutoHotkey.Generate.Name where
 
+import qualified Data.Text as Text
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
 import qualified Idris.Core.TT as Idris (Name, showCG)
 import IdrisCG.AutoHotkey.Syntax (Name (..))
 import Relude
@@ -8,10 +11,28 @@ notAllowedSymbols :: String
 notAllowedSymbols = "{}[]()"
 
 generate :: Idris.Name -> Name
-generate idrisName = do
-  let removeSymbols = filter (`notElem` notAllowedSymbols)
-  let encodedName = Idris.showCG idrisName & removeSymbols
-  Name (toText encodedName)
+generate idrisName =
+  new (Idris.showCG idrisName)
+
+new :: ToText a => a -> Name
+new s = do
+  let removeSymbols =
+        Text.filter (`notElem` notAllowedSymbols)
+  let replaceDots =
+        Text.replace "." "__"
+  let replaceDashes =
+        Text.replace "-" "_"
+  let encodedName =
+        toText s
+          & removeSymbols
+          & replaceDots
+          & replaceDashes
+  Name encodedName
+
+random :: MonadIO m => m Name
+random = do
+  uuid <- liftIO UUID.nextRandom
+  pure (new $ "f" <> UUID.toText uuid)
 
 loc :: Int -> Name
 loc i = Name ("loc" <> show i)

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Name.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Name.hs
@@ -3,12 +3,15 @@ module IdrisCG.AutoHotkey.Generate.Name where
 import qualified Idris.Core.TT as Idris (Name, showCG)
 import IdrisCG.AutoHotkey.Syntax (Name (..))
 import Relude
-import Text.Encoding.Z (zEncodeString)
+
+notAllowedSymbols :: String
+notAllowedSymbols = "{}[]()"
 
 generate :: Idris.Name -> Name
 generate idrisName = do
-  let encodedName = zEncodeString (Idris.showCG idrisName)
-  Name ("idris_" <> toText encodedName)
+  let removeSymbols = filter (`notElem` notAllowedSymbols)
+  let encodedName = Idris.showCG idrisName & removeSymbols
+  Name (toText encodedName)
 
 loc :: Int -> Name
 loc i = Name ("loc" <> show i)

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/PrimFunction.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/PrimFunction.hs
@@ -1,6 +1,7 @@
 module IdrisCG.AutoHotkey.Generate.PrimFunction where
 
 import qualified IRTS.Lang as Idris (PrimFn (..))
+import IdrisCG.AutoHotkey.Generate.Common
 import qualified IdrisCG.AutoHotkey.Generate.Name as Name
 import IdrisCG.AutoHotkey.Syntax (Expression (..))
 import Relude
@@ -9,7 +10,7 @@ generate :: Idris.PrimFn -> [Expression] -> Expression
 generate Idris.LWriteStr [_, str] =
   Apply (Variable "idris_putStr") [str]
 generate (Idris.LExternal n) params =
-  Apply (Variable $ Name.generate n) params
+  Apply (thisDot $ Variable $ Name.generate n) params
 generate Idris.LCrash args =
   Apply (Variable "idris_crash") args
 generate x _ =

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/Program.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/Program.hs
@@ -11,6 +11,6 @@ generate :: [(IdrisCore.Name, Idris.LDecl)] -> Syntax.Program
 generate definitions = do
   let functions = fmap TopLevel.generate definitions
   let mainName = Name.generate (IdrisCore.sMN 0 "runMain")
-  let start = Syntax.Call mainName []
+  let start = Syntax.Call (Syntax.Variable mainName) []
   let statements = functions <> [start]
   Syntax.Program statements

--- a/codegen/src/IdrisCG/AutoHotkey/Generate/TopLevel.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Generate/TopLevel.hs
@@ -3,12 +3,16 @@ module IdrisCG.AutoHotkey.Generate.TopLevel where
 import qualified IRTS.Lang as Idris (LDecl (..))
 import qualified Idris.Core.TT as Idris (Name)
 import qualified IdrisCG.AutoHotkey.Generate.Block as Block
+import IdrisCG.AutoHotkey.Generate.Common
 import qualified IdrisCG.AutoHotkey.Generate.Name as Name
-import IdrisCG.AutoHotkey.Syntax (Statement (..))
+import IdrisCG.AutoHotkey.Syntax
 import Relude
 
-generate :: (Idris.Name, Idris.LDecl) -> Statement
-generate (functionName, Idris.LFun _ _ args definition) =
-  Function (Name.generate functionName) (fmap Name.generate args) (Block.generate Return definition)
-generate (_, Idris.LConstructor {}) =
-  NoOp
+generate :: MonadIO m => Name -> (Idris.Name, Idris.LDecl) -> m Statement
+generate programName (functionName, Idris.LFun _ _ args definition) = do
+  let funName = Name.generate functionName
+  let funArgs = Name.generate <$> args
+  let funBody = Function (Name "run") funArgs (copyFunArgs funArgs <> Block.generate Return definition)
+  pure $ Class funName (Just programName) [funBody]
+generate _ (_, Idris.LConstructor {}) =
+  pure NoOp

--- a/codegen/src/IdrisCG/AutoHotkey/Syntax.hs
+++ b/codegen/src/IdrisCG/AutoHotkey/Syntax.hs
@@ -31,6 +31,7 @@ data Expression
   | Variable Name
   | Apply Expression [Expression]
   | Projection Expression Expression
+  | DotAccess Expression Expression
   deriving (Eq, Show)
 
 type Block = [Statement]
@@ -43,17 +44,17 @@ data ConditionalStatement
   deriving (Eq, Show)
 
 data Statement
-  = Let Name Expression
-  | Return Expression
+  = Return Expression
   | While Expression Block
   | Break
   | Continue
   | Function Name [Name] Block
-  | Call Name [Expression]
+  | Call Expression [Expression]
   | Condition ConditionalStatement
-  | Assignment Name Expression
+  | Assignment Expression Expression
   | NoOp
   | Command Name [Expression]
+  | Class Name (Maybe Name) [Statement]
   deriving (Eq, Show)
 
 newtype Program = Program [Statement]

--- a/examples/HelloWorld.idr
+++ b/examples/HelloWorld.idr
@@ -1,10 +1,6 @@
 import AutoHotkey.Builtins
 import AutoHotkey.FFI
 
-foo : String
-foo =
-  let x = \y => y ++ "from Idris!"
-  in x "Hello AutoHotkey, "
-
 main : AHK_IO ()
-main = msgBox foo
+main =
+  msgBox "Hello AutoHotkey, from Idris!"

--- a/examples/SimpleFeatures.idr
+++ b/examples/SimpleFeatures.idr
@@ -1,0 +1,13 @@
+import AutoHotkey.Builtins
+import AutoHotkey.FFI
+
+foo : String
+foo =
+  let x = \y => y ++ "from Idris!"
+  in x "Hello AutoHotkey, "
+
+main : AHK_IO ()
+main = do
+  x <- pure "lol"
+  msgBox x
+  msgBox x

--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ dependencies:
   - zenc
   - text
   - file-embed
+  - uuid
 
 library:
   source-dirs:


### PR DESCRIPTION
This PR adds a bunch of interesting stuff:

* Now scopes are denoted by classes
  * This means, 1 Idris scope == 1 AutoHotkey class.
  * This allows to share context with underlying functions, i.e. lambdas (not implemented yet)
  * The global scope is enclosed in a class with a randomized name in order to avoid name 
clashes with possible AutoHotkey libraries.
  * Functions move their arguments into the `this` scope as soon as they start
  * All variable accesses, and function calls are prefixed now with `this.`
* Names are not prefixed with `idris_` by default
* Names are not Z-encoded by default, and rather we remove unnecessary symbols, so the autogenerated code is much readable now.

# TL;DR

The Idris code

```idris
module Main where

main : AHK_IO ()
main =
  msgBox "Hello AutoHotkey, from Idris!"
```

now compiles to this:

```autohotkey
class fca1549bb_4a88_4c7b_980a_c368cb3d082c {
    class Main__main extends fca1549bb_4a88_4c7b_980a_c368cb3d082c
    {
        run()
        {
            global
            MsgBox, % "Hello AutoHotkey, from Idris!"
        }
    }
    ...
}
;; call to Main__main.run here
```