### PR TITLE
perf: Minify primitive functions

### DIFF
--- a/codegen/rts/rts.ahk
+++ b/codegen/rts/rts.ahk
@@ -1,16 +1,17 @@
-#Warn
-
-idris_putStr(x)
+class __drahko
 {
-  MsgBox % x
-}
+  putStr(x)
+  {
+    MsgBox % x
+  }
 
-TheWorld()
-{
-  return ""
-}
+  TheWorld()
+  {
+    return ""
+  }
 
-idris_crash(msg)
-{
-  throw Exception(msg, -1)
+  crash(msg)
+  {
+    throw Exception(msg, -1)
+  }
 }

--- a/codegen/src/Drahko/Generate/Constant.hs
+++ b/codegen/src/Drahko/Generate/Constant.hs
@@ -10,5 +10,6 @@ generate = \case
   (Idris.Ch c) -> (Literal . String $ one c)
   (Idris.BI i) -> (Literal $ Integer i)
   (Idris.Str s) -> (Literal . String $ toText s)
+  Idris.TheWorld -> (Literal $ String "")
   x | isTypeConst x -> (Literal $ String "")
   x -> error ("\nConstant not implemented \n\n\t" <> show x <> "\n")

--- a/codegen/src/Drahko/Generate/PrimFunction.hs
+++ b/codegen/src/Drahko/Generate/PrimFunction.hs
@@ -2,16 +2,20 @@ module Drahko.Generate.PrimFunction where
 
 import Drahko.Generate.Common
 import qualified Drahko.Generate.Name as Name
-import Drahko.Syntax (Expression (..))
+import Drahko.Syntax
 import qualified IRTS.Lang as Idris (PrimFn (..))
 import Relude
 
 generate :: Idris.PrimFn -> [Expression] -> Expression
 generate Idris.LWriteStr [_, str] =
-  Apply (Variable "idris_putStr") [str]
+  Apply (primitiveFunction "putStr") [str]
 generate (Idris.LExternal n) params =
   Apply (thisDot $ Variable $ Name.generate n) params
 generate Idris.LCrash args =
-  Apply (Variable "idris_crash") args
+  Apply (primitiveFunction "crash") args
 generate x _ =
   error ("\nPrimitive function not implemented \n\n\t" <> show x <> "\n")
+
+primitiveFunction :: Text -> Expression
+primitiveFunction nameText =
+  DotAccess (Variable "__drahko") (Variable $ Name nameText)

--- a/codegen/src/Drahko/Generate/TopLevel.hs
+++ b/codegen/src/Drahko/Generate/TopLevel.hs
@@ -5,14 +5,61 @@ import Drahko.Generate.Common
 import qualified Drahko.Generate.Name as Name
 import Drahko.Syntax
 import qualified IRTS.Lang as Idris (LDecl (..))
-import qualified Idris.Core.TT as Idris (Name)
+import qualified Idris.Core.TT as Idris
 import Relude
 
 generate :: MonadIO m => Name -> (Idris.Name, Idris.LDecl) -> m Statement
-generate programName (functionName, Idris.LFun _ _ args definition) = do
-  let funName = Name.generate functionName
-  let funArgs = Name.generate <$> args
-  let funBody = Function (Name "run") funArgs (copyFunArgs funArgs <> Block.generate Return definition)
-  pure $ Class funName (Just programName) [funBody]
+generate programName (functionName, Idris.LFun _ _ args definition)
+  | Idris.showCG functionName `elem` ignoredTopLevels = pure NoOp
+  | otherwise = do
+    let funName = Name.generate functionName
+    let funArgs = Name.generate <$> args
+    let funBody = Function (Name "run") funArgs (copyFunArgs funArgs <> Block.generate Return definition)
+    pure $ Class funName (Just programName) [funBody]
 generate _ (_, Idris.LConstructor {}) =
   pure NoOp
+
+ignoredTopLevels :: [String]
+ignoredTopLevels =
+  primitiveFunctions
+    <> [ "unsafePerformPrimIO",
+         "run__IO",
+         "call__IO",
+         "mkForeignPrim",
+         "idris_crash",
+         "assert_unreachable"
+       ]
+  where
+    primitiveFunctions =
+      map
+        ("prim__" <>)
+        [ "writeFile",
+          "vm",
+          "stdout",
+          "stdin",
+          "stderr",
+          "sizeofPtr",
+          "registerPtr",
+          "readFile",
+          "readChars",
+          "ptrOffset",
+          "pokeSingle",
+          "pokePtr",
+          "pokeDouble",
+          "poke8",
+          "poke64",
+          "poke32",
+          "poke16",
+          "peekSingle",
+          "peekPtr",
+          "peekDouble",
+          "peek8",
+          "peek64",
+          "peek32",
+          "peek16",
+          "null",
+          "managedNull",
+          "eqPtr",
+          "eqManagedPtr",
+          "asPtr"
+        ]


### PR DESCRIPTION
This PR reduces the minimal output code from ~500 lines of AHK to ~20 lines of AHK , without taking into account the Runtime support (the `rts.ahk` file).

Also, it groups all the primitive functions under the `__drahko` class, so they don't clash with any global functions.

Fixes #7 